### PR TITLE
⬆️ build: update android gradle plugin - KOCHA-222

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -7,7 +7,7 @@ object Apps {
 }
 
 object Versions {
-    const val androidGradle = "7.2.1"
+    const val androidGradle = "7.3.1"
     const val kotlin = "1.7.0"
     const val compose = "1.1.1"
     const val objectBox = "3.2.0"

--- a/integration-test-app/build.gradle.kts
+++ b/integration-test-app/build.gradle.kts
@@ -16,6 +16,7 @@ plugins {
 val version = getAppVersion()
 
 android {
+    namespace = "com.eidu.integration.test.app"
     compileSdk = Apps.compileSdk
     buildToolsVersion = Apps.buildToolsVersion
 

--- a/integration-test-app/src/main/AndroidManifest.xml
+++ b/integration-test-app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.eidu.integration.test.app">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" tools:ignore="QueryAllPackagesPermission" />
 


### PR DESCRIPTION
**Asana Task**
[app.asana.com/0/1201864995605426/1202487961427389/f](https://app.asana.com/0/1201864995605426/1202487961427389/f)

**Background**
AGP versions <7.3 have a vulnerability. This PR updates the plugin to version the most recent version 7.3.1

**Notes**
This PR also moves the namespace to the gradle build file, having it in the Manifest is deprecated.